### PR TITLE
Allow overrides

### DIFF
--- a/src/Piqure.spec.ts
+++ b/src/Piqure.spec.ts
@@ -35,12 +35,13 @@ describe('Piqure', () => {
     expect(inject(SECOND_KEY)).toBe('Text');
   });
 
-  it('Should not provide for same key multiple times', () => {
-    const { provide } = piqure();
+  it('Should override existing key', () => {
+    const { inject, provide } = piqure();
     const KEY = key<string>('Key');
     provide(KEY, 'Value');
+    provide(KEY, 'New value')
 
-    expect(() => provide(KEY, 'New value')).toThrow('The value for the key Symbol(Key) already exists');
+    expect(inject(KEY)).toBe('New value');
   });
 
   describe('With memory', () => {

--- a/src/Piqure.ts
+++ b/src/Piqure.ts
@@ -23,9 +23,6 @@ export const piqureWrapper = (wrapper: object, field: string): Piqure => {
 
 export const piqure = (memory: Map<unknown, unknown> = new Map()): Piqure => {
   const provide: Provide = (key, injected) => {
-    if (memory.has(key)) {
-      throw new Error(`The value for the key ${key.toString()} already exists`);
-    }
     memory.set(key, injected);
   };
 


### PR DESCRIPTION
Overriding existing keys is usefull, for example when you want to provide a mock implementation for testing purposes