### PR TITLE
Fix: type and must be imported using a type-only import when verbatim ModuleSyntax is enabled

### DIFF
--- a/src/Piqure.ts
+++ b/src/Piqure.ts
@@ -1,5 +1,5 @@
-import { InjectionKey, Provide, ProvideLazy } from './Providing';
-import { LazyValue, StaticValue, Value } from './Value';
+import type { InjectionKey, Provide, ProvideLazy } from './Providing';
+import { LazyValue, StaticValue, type Value } from './Value';
 
 export type ProvidePair<T> = [InjectionKey<T>, T];
 

--- a/src/Value.ts
+++ b/src/Value.ts
@@ -1,4 +1,4 @@
-import { Provider } from './Providing';
+import { type Provider } from './Providing';
 
 const ABSENT = Symbol('Absent');
 


### PR DESCRIPTION
Related to https://github.com/jhipster/jhipster-lite/pull/11128