### PR TITLE
feat: add keyFor for global symbol support

### DIFF
--- a/src/Piqure.spec.ts
+++ b/src/Piqure.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { key, piqure, piqureWrapper } from './Piqure';
+import { key, keyFor, piqure, piqureWrapper } from './Piqure';
 
 describe('Piqure', () => {
   it.each([
@@ -42,6 +42,13 @@ describe('Piqure', () => {
     provide(KEY, 'New value');
 
     expect(inject(KEY)).toBe('New value');
+  });
+
+  it('Should create unique symbols for each key call with the same description', () => {
+    const FIRST_KEY = key<string>('Key');
+    const SECOND_KEY = key<string>('Key');
+
+    expect(FIRST_KEY).not.toBe(SECOND_KEY);
   });
 
   describe('With memory', () => {
@@ -88,7 +95,7 @@ describe('Piqure', () => {
   });
 
   describe('Lazy Provider', () => {
-    it('should get lazy value', () => {
+    it('Should get lazy value', () => {
       const { provideLazy, inject } = piqure();
       const LAZY_KEY = key('Lazy key');
       provideLazy(LAZY_KEY, () => 'Lazy value');
@@ -96,7 +103,7 @@ describe('Piqure', () => {
       expect(inject(LAZY_KEY)).toBe('Lazy value');
     });
 
-    it('should get value once', () => {
+    it('Should get value once', () => {
       const { provideLazy, inject } = piqure();
       let count = 0;
       const LAZY_KEY = key('Lazy key');
@@ -110,6 +117,31 @@ describe('Piqure', () => {
       inject(LAZY_KEY);
 
       expect(count).toBe(1);
+    });
+  });
+
+  describe('keyFor', () => {
+    it('Should return the same symbol for the same description', () => {
+      const FIRST_KEY = keyFor<string>('Key');
+      const SECOND_KEY = keyFor<string>('Key');
+
+      expect(FIRST_KEY).toBe(SECOND_KEY);
+    });
+
+    it('Should be different from key with the same description', () => {
+      const LOCAL_KEY = key<string>('Key');
+      const GLOBAL_KEY = keyFor<string>('Key');
+
+      expect(LOCAL_KEY).not.toBe(GLOBAL_KEY);
+    });
+
+    it('Should work with provide and inject', () => {
+      const { provide, inject } = piqure();
+      const GLOBAL_KEY = keyFor<string>('my-service');
+
+      provide(GLOBAL_KEY, 'injected value');
+
+      expect(inject(GLOBAL_KEY)).toBe('injected value');
     });
   });
 });

--- a/src/Piqure.ts
+++ b/src/Piqure.ts
@@ -43,3 +43,5 @@ export const piqure = (memory: Map<unknown, Value<unknown>> = new Map()): Piqure
 };
 
 export const key = <T>(description: string): InjectionKey<T> => Symbol(description) as InjectionKey<T>;
+
+export const keyFor = <T>(description: string): InjectionKey<T> => Symbol.for(description) as InjectionKey<T>;


### PR DESCRIPTION
This enables compatibility with React Server Components, which require global symbols for serialization between server and client boundaries.

## 📖 Context
When using piqure with Next.js App Router (React Server Components), injection keys created with key() cannot be passed from Server Components to Client Components.

## ⚠️ Problem
React Server Components can only serialize global symbols. Local symbols created with Symbol() fail with:                                     
```
Error: Only global symbols received from Symbol.for(...) can be passed to Client Components. The symbol Symbol(my-key) cannot be found among global symbols.
```

This happens because key() uses Symbol(description), which creates a unique local symbol on each call.

## ✅ Solution
Add `keyFor()` function that uses `Symbol.for()` to create global symbols. These symbols are registered in a global registry and can be serialized across server/client boundaries.

```
// Before (fails with RSC)
const MY_KEY = key<MyService>('my-service'):
```
```
// After (works with RSC)
const MY_KEY = keyFor<MyService>('my-service');
```

## 🤔 Why not change key() directly?

`Symbol.for()` uses a global registry, which means any code knowing the description can access the same symbol. This reduces isolation compared to Symbol(). Keeping both functions lets users choose based on their environment:
- `key()` : strict isolation, for non-RSC environments
- `keyFor()` : global symbols, required for RSC compatibility

## 📸 Screenshot
<img width="945" height="271" alt="image" src="https://github.com/user-attachments/assets/36f02563-1e68-4af3-85b7-ffc603e28585" />