### PR TITLE
feat: add 'has' method to Piqure

### DIFF
--- a/src/Piqure.spec.ts
+++ b/src/Piqure.spec.ts
@@ -167,6 +167,9 @@ describe('Piqure', () => {
       provideLazy(k, () => 'hello');
 
       expect(has(k)).toBe(true);
+    });
+  });
+
   describe('Circular dependencies', () => {
     it('Should throw when a lazy key directly depends on itself', () => {
       const { provideLazy, inject } = piqure();

--- a/src/Piqure.spec.ts
+++ b/src/Piqure.spec.ts
@@ -144,4 +144,29 @@ describe('Piqure', () => {
       expect(inject(GLOBAL_KEY)).toBe('injected value');
     });
   });
+
+  describe('has(key)', () => {
+    it('Should return true if the key is provided', () => {
+      const { provide, has } = piqure();
+      const KEY = key<string>('Key');
+      provide(KEY, 'Value');
+
+      expect(has(KEY)).toBe(true);
+    });
+
+    it('Should return false if the key is not provided', () => {
+      const { has } = piqure();
+      const KEY = key<string>('Key');
+
+      expect(has(KEY)).toBe(false);
+    });
+
+    it('Should return true when key is provided lazily', () => {
+      const { provideLazy, has } = piqure();
+      const k = key<string>('lazy-key');
+      provideLazy(k, () => 'hello');
+
+      expect(has(k)).toBe(true);
+    });
+  });
 });

--- a/src/Piqure.ts
+++ b/src/Piqure.ts
@@ -8,6 +8,7 @@ interface Piqure {
   provideLazy: ProvideLazy;
   inject: <T>(key: InjectionKey<T>) => T;
   provides: (list: ProvidePair<unknown>[]) => void;
+  has: (key: InjectionKey<unknown>) => boolean;
 }
 
 export const piqureWrapper = (wrapper: object, field: string): Piqure => {
@@ -30,6 +31,9 @@ export const piqure = (memory: Map<unknown, Value<unknown>> = new Map()): Piqure
   return {
     provide,
     provideLazy,
+    has(key) {
+      return memory.has(key);
+    },
     inject<T>(key: InjectionKey<T>): T {
       if (!memory.has(key)) {
         throw new Error(`The key ${key.toString()} is not provided`);


### PR DESCRIPTION
## 📖 Context

In case you need to handle optional dependencies, registering a fallback only if a key is not already provided, or conditionally injecting a service depending on the environment.

## ⚠️ Problem
The only way to check if a key is registered was to call `inject()` and catch
the error it throws:

```ts
try {
  const service = inject(MY_KEY);
} catch {
  // key not registered
}
```

This is verbose, error-prone, and abuses exceptions for control flow.

## ✅ Solution
Add a `has(key)` method that returns `true` if the key is registered,
`false` otherwise, without throwing.

```ts
// Before
try {
  inject(MY_KEY);
} catch { ... }

// After
if (has(MY_KEY)) {
  inject(MY_KEY);
}
```

Works with both `provide` and `provideLazy`.

## 🧪 Tests
Three cases added to `Piqure.spec.ts` :
- returns `true` when the key is registered via `provide`
- returns `false` when the key is not registered
- returns `true` when the key is registered via `provideLazy`