### PR TITLE
fix: circular depedencies

### DIFF
--- a/src/Piqure.spec.ts
+++ b/src/Piqure.spec.ts
@@ -144,4 +144,37 @@ describe('Piqure', () => {
       expect(inject(GLOBAL_KEY)).toBe('injected value');
     });
   });
+
+  describe('Circular dependencies', () => {
+    it('Should throw when a lazy key directly depends on itself', () => {
+      const { provideLazy, inject } = piqure();
+      const A = key('A');
+
+      provideLazy(A, () => inject(A));
+
+      expect(() => inject(A)).toThrow('Circular dependency detected for key Symbol(A)');
+    });
+
+    it('Should throw when lazy keys form an indirect cycle', () => {
+      const { provideLazy, inject } = piqure();
+      const A = key('A');
+      const B = key('B');
+
+      provideLazy(A, () => inject(B));
+      provideLazy(B, () => inject(A));
+
+      expect(() => inject(A)).toThrow('Circular dependency detected for key Symbol(A)');
+    });
+
+    it('Should not throw for a non-circular dependency chain', () => {
+      const { provideLazy, inject } = piqure();
+      const A = key('A');
+      const B = key('B');
+
+      provideLazy(B, () => 'value-b');
+      provideLazy(A, () => inject(B));
+
+      expect(inject(A)).toBe('value-b');
+    });
+  });
 });

--- a/src/Piqure.ts
+++ b/src/Piqure.ts
@@ -27,6 +27,8 @@ export const piqure = (memory: Map<unknown, Value<unknown>> = new Map()): Piqure
     memory.set(key, new LazyValue(provider));
   };
 
+  const resolving = new Set();
+
   return {
     provide,
     provideLazy,
@@ -34,7 +36,18 @@ export const piqure = (memory: Map<unknown, Value<unknown>> = new Map()): Piqure
       if (!memory.has(key)) {
         throw new Error(`The key ${key.toString()} is not provided`);
       }
-      return memory.get(key)?.get() as T;
+
+      if (resolving.has(key)) {
+        throw new Error(`Circular dependency detected for key ${key.toString()}`);
+      }
+
+      resolving.add(key);
+
+      try {
+        return memory.get(key)?.get() as T;
+      } finally {
+        resolving.delete(key);
+      }
     },
     provides(list) {
       list.forEach(([key, value]) => provide(key, value));


### PR DESCRIPTION
## 📖 Context

While exploring the library's limits, it became clear that lazy providers can call `inject()` internally to resolve their own dependencies.

This is a legitimate and common pattern, but it opens a silent failure mode that is hard to debug.

## ⚠️ Problem

When two lazy providers depend on each other (directly or indirectly), calling `inject()` triggers infinite recursion with no useful error:

```ts
const A = key('A')
const B = key('B')

provideLazy(A, () => {
  inject(B) // A depends to B
})

provideLazy(B, () => {
  inject(A) // B depends to A
})

inject(A) // stack overflow --> infinite loop
```

The stack overflow gives no indication of which keys are involved or why the cycle formed.

## ✅ Solution

Track which keys are currently being resolved using a `Set` in the container closure. Before executing a lazy provider, check if its key is already in that set. If yes, a cycle is detected and a clear error is thrown immediately.

```ts
inject(A);
// Circular dependency detected for key Symbol(A)
```

Works for both direct cycles (A → A) and indirect cycles (A → B → A).
Non-circular chains (A → B where B has no dependency on A) are unaffected.

## 🤔 Why a Set in the closure?

The `Set` lives in the `piqure()` closure, so it is shared across all `inject()` calls within the same container. This means when resolving A triggers resolving B, B can see that A is still in the set and so throw before the recursion goes further.

## 🧪 Tests

Three cases added to `Piqure.spec.ts` under `describe('Circular dependencies')` :

- direct cycle: a lazy key whose provider injects itself
- indirect cycle: two lazy keys that depend on each other
- regression: a non-circular chain (A → B) still resolves correctly
